### PR TITLE
rswitch: fix random crashes due to erroneous pointer use

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -1697,7 +1697,7 @@ static int rswitch_etha_set_access(struct rswitch_etha *etha, bool read,
 		return ret;
 
 	/* Clear address completion flag */
-	rswitch_modify(etha, MMIS1, MMIS1_PAACS, MMIS1_PAACS);
+	rswitch_etha_modify(etha, MMIS1, MMIS1_PAACS, MMIS1_PAACS);
 
 	/* Read/Write PHY register */
 	if (read) {


### PR DESCRIPTION
rswitch_modify() accepts pointer to a MMIO region while rswitch_etha_modify() extracts this pointer from etha structure. So prior to this patch, this code changed memory somewhere in a kernel heap, damaging random kernel structures, which sometimes led to a kernel crash.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>